### PR TITLE
Remove special casing on primitive types by casting 0 to type.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -254,20 +254,8 @@ macro_rules! concat_slices {
         $crate::_concat_slices!([$init; $T]: $($s),*)
     };
 
-    ([char]: $($s:expr),* $(,)?) => {
-        $crate::concat_slices!(['\x00'; char]: $($s),*)
-    };
-
-    ([f32]: $($s:expr),* $(,)?) => {
-        $crate::concat_slices!([0.0; f32]: $($s),*)
-    };
-
-    ([f64]: $($s:expr),* $(,)?) => {
-        $crate::concat_slices!([0.0; f64]: $($s),*)
-    };
-
     ([$T:ty]: $($s:expr),* $(,)?) => {
-        $crate::concat_slices!([0; $T]: $($s),*)
+        $crate::concat_slices!([0 as $T; $T]: $($s),*)
     };
 }
 


### PR DESCRIPTION
This change will allow using more primitive types with the macro by casting 0 to the provided type.

Types that can be casted from a zero include but are not limited to; All numeric types, `char`, `*const T` (raw pointer).
Meaning special casing for `f32`, `f64` and `char` can be removed. Which were added after issue https://github.com/rossmacarthur/constcat/issues/2.

I have tested compile times in a small application, but noticed very little, to no difference.

One more very small thing this helps in is syntax highlighting in editors, since the macro takes a type rather than a literal type name it displays the correct color for it. See screenshots from the testing file below.

OLD: 
![image](https://github.com/rossmacarthur/constcat/assets/111659262/7833c411-064d-47d4-905c-8c0d7a4284f9)
NEW:
![image](https://github.com/rossmacarthur/constcat/assets/111659262/eafed778-38c9-4a92-bbb0-bc285281790a)
