### PR TITLE
Allow slice concatenation without initial value.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -290,7 +290,7 @@ macro_rules! _concat_slices {
             // Mentioned case is handled above as a comp time panic above.
             //
             // See for more information: https://doc.rust-lang.org/core/mem/union.MaybeUninit.html#initializing-an-array-element-by-element
-            unsafe {core::mem::transmute(arr)}
+            unsafe { $crate::core::mem::transmute(arr) }
         };
         &ARR
     }};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -280,12 +280,16 @@ macro_rules! _concat_slices {
 
             // SAFETY: Transmuting an array of initialized MaybeUninit's is completely safe, where
             // all of its items are initialized.
+            // As per the documentation of `core::mem::MaybeUninit`: "https://doc.rust-lang.org/core/mem/union.MaybeUninit.html#layout-1"
+            // This means it is safe to transmute as the slices must be the same type in order to
+            // be placed in the array. In such case the user does provide slices with different
+            // types, it would give a compile error before even reaching the unsafe block.
             //
             // The only way it would be UB is where `base` and the array length (`LEN`) is
             // different, as it would end up assuming the non-initialized items do exist.
             // Mentioned case is handled above as a comp time panic above.
             //
-            // See https://doc.rust-lang.org/core/mem/union.MaybeUninit.html#initializing-an-array-element-by-element
+            // See for more information: https://doc.rust-lang.org/core/mem/union.MaybeUninit.html#initializing-an-array-element-by-element
             unsafe {core::mem::transmute(arr)}
         };
         &ARR

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -281,7 +281,7 @@ macro_rules! _concat_slices {
             // SAFETY: Transmuting an array of initialized MaybeUninit's is completely safe, where
             // all of its items are initialized.
             // As per the documentation of `core::mem::MaybeUninit`: "https://doc.rust-lang.org/core/mem/union.MaybeUninit.html#layout-1"
-            // This means it is safe to transmute as the slices must be the same type in order to
+            // This means it is safe to transmute, as the slices must be the same type in order to
             // be placed in the array. In such case the user does provide slices with different
             // types, it would give a compile error before even reaching the unsafe block.
             //

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -63,17 +63,12 @@
 //! const HEADER: &[i32] = concat_slices!([i32]: MAGIC, &[0, VERSION]);
 //! ```
 //!
-//! If the type is not a std integer, `f32`, `f64`, or `char` type then you must
-//! also provide an initializer expression with the type, in the form `[init;
-//! T]: `. This also works for custom types as long as the type and initializer
-//! expression is able to be specified in an array initializer expression.
-//!
 //! ```
 //! # use constcat::concat_slices;
 //! #
 //! const PRIMARIES: &'static [(u8, u8, u8)] = &[(255, 0, 0), (0, 255, 0), (0, 0, 255)];
 //! const SECONDARIES: &'static [(u8, u8, u8)] = &[(255, 255, 0), (255, 0, 255), (0, 255, 255)];
-//! const COLORS: &[(u8, u8, u8)] = concat_slices!([(0, 0, 0); (u8, u8, u8)]: PRIMARIES, SECONDARIES);
+//! const COLORS: &[(u8, u8, u8)] = concat_slices!([(u8, u8, u8)]: PRIMARIES, SECONDARIES);
 //! ```
 //!
 //! [`std::concat!`]: core::concat
@@ -225,26 +220,18 @@ macro_rules! _maybe_std_concat_bytes {
 ///   concat_slices!([usize]: /* ... */);
 ///   ```
 ///
-/// - If the type is not a std integer, `f32`, `f64`, or `char` type then you
-///   must also provide an initializer expression.
-///
 ///   ```
 ///   # use constcat::concat_slices;
-///   concat_slices!([(0, 0, 0); (u8, u8, u8)]: /* ... */);
+///   concat_slices!([(u8, u8, u8)]: /* ... */);
 ///   ```
-/// - This also works for custom types as long as the type and initializer
-///   expression is able to be specified in an array initializer expression.
+/// - This also works for custom types as long as the type implement `Copy`.
 ///
 ///   ```
 ///   # use constcat::concat_slices;
 ///   #[derive(Clone, Copy)]
 ///   struct i256(i128, i128);
 ///
-///   impl i256 {
-///       const fn new() -> Self { Self(0, 0) }
-///   }
-///
-///   concat_slices!([i256::new(); i256]: /* ... */);
+///   concat_slices!([i256]: /* ... */);
 ///   ```
 ///
 /// See the [crate documentation][crate] for examples.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -256,7 +256,6 @@ macro_rules! _concat_slices {
     }};
 
     ([$T:ty]: $($s:expr),+) => {{
-        extern crate core;
         $(
             const _: &[$T] = $s; // require constants
         )*

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -262,7 +262,7 @@ macro_rules! _concat_slices {
         )*
         const LEN: usize = $( $s.len() + )* 0;
         const ARR: [$T; LEN] = {
-        use core::mem::MaybeUninit;
+            use $crate::core::mem::MaybeUninit;
             let mut arr: [MaybeUninit<$T>; LEN] = [MaybeUninit::zeroed(); LEN];
             let mut base: usize = 0;
             $({

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -237,11 +237,6 @@ macro_rules! _maybe_std_concat_bytes {
 /// See the [crate documentation][crate] for examples.
 #[macro_export]
 macro_rules! concat_slices {
-    ([$init:expr; $T:ty]: $($s:expr),* $(,)?) => {
-        $crate::_concat_slices!([$T]: $($s),*)
-    };
-
-    // Left in for backwards compatiblity.
     ([$T:ty]: $($s:expr),* $(,)?) => {
         $crate::_concat_slices!([$T]: $($s),*)
     };

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -291,10 +291,13 @@ macro_rules! _concat_slices {
             })*
             if base != LEN { panic!("invalid length"); }
 
-            // SAFETY: Transmuting an array of initialized MaybeUninit's is completely safe.
+            // SAFETY: Transmuting an array of initialized MaybeUninit's is completely safe, where
+            // all of its items are initialized.
+            //
             // The only way it would be UB is where `base` and the array length (`LEN`) is
             // different, as it would end up assuming the non-initialized items do exist.
             // Mentioned case is handled above as a comp time panic above.
+            //
             // See https://doc.rust-lang.org/core/mem/union.MaybeUninit.html#initializing-an-array-element-by-element
             unsafe {core::mem::transmute(arr)}
         };

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -268,12 +268,13 @@ macro_rules! _concat_slices {
     }};
 
     ([$init:expr; $T:ty]: $($s:expr),+) => {{
+        extern crate core;
         $(
             const _: &[$T] = $s; // require constants
         )*
         const LEN: usize = $( $s.len() + )* 0;
         const ARR: [$T; LEN] = {
-            let mut arr: [$T; LEN] = [$init; LEN];
+            let mut arr: [$T; LEN] = unsafe {core::mem::MaybeUninit::zeroed().assume_init()};
             let mut base: usize = 0;
             $({
                 let mut i = 0;

--- a/tests/smoke.rs
+++ b/tests/smoke.rs
@@ -66,38 +66,22 @@ fn concat_slices_smoke() {
     const TEST1: &[i32] = concat_slices!([i32]:,);
     assert_eq!(TEST1, []);
 
-    const TEST2: &[i32] = concat_slices!([i32]: &[1, 2, 3]);
+    const TEST2: &[i32] = concat_slices!([i32]: &[1, 2, 3],);
     assert_eq!(TEST2, [1, 2, 3]);
 
-    const TEST3: &[i32] = concat_slices!([i32]: &[1, 2, 3],);
-    assert_eq!(TEST3, [1, 2, 3]);
+    const TEST3: &[i32] = concat_slices!([i32]: &[1, 2, 3], TEST2);
+    assert_eq!(TEST3, [1, 2, 3, 1, 2, 3]);
 
-    const TEST4: &[i32] = concat_slices!([i32]: &[1, 2, 3], TEST3);
-    assert_eq!(TEST4, [1, 2, 3, 1, 2, 3]);
+    const TEST4: &[f32] = concat_slices!([f32]: &[1.], &[2.], &[3.]);
+    assert_eq!(TEST4, [1., 2., 3.]);
 
-    const TEST5: &[f32] = concat_slices!([f32]: &[1.], &[2.], &[3.]);
-    assert_eq!(TEST5, [1., 2., 3.]);
-
-    const TEST6: &[char] = concat_slices!([char]: &['a'], &['b'], &['c']);
-    assert_eq!(TEST6, ['a', 'b', 'c']);
-
-    const TEST7: &[f32] = concat_slices!([1.0; f32]: &[1.], &[2.], &[3.]);
-    assert_eq!(TEST7, [1., 2., 3.]);
-
-    const TEST8: &[char] = concat_slices!(['0'; char]: &['a'], &['b'], &['c']);
-    assert_eq!(TEST8, ['a', 'b', 'c']);
+    const TEST5: &[char] = concat_slices!([char]: &['a'], &['b'], &['c']);
+    assert_eq!(TEST5, ['a', 'b', 'c']);
 
     #[derive(Debug, Clone, Copy, PartialEq, Eq)]
     struct I(i32);
-    const TEST9: &[I] = concat_slices!([I(0); I]: &[I(1), I(2), I(3)]);
-    assert_eq!(TEST9, [I(1), I(2), I(3)]);
-
-    const DEF: I = I(123);
-    const TEST10: &[I] = concat_slices!([DEF; I]: &[I(1), I(2), I(3)]);
-    assert_eq!(TEST10, [I(1), I(2), I(3)]);
-
-    const TEST11: &[I] = concat_slices!([I]: &[I(1), I(2), I(3)]);
-    assert_eq!(TEST10, TEST11);
+    const TEST6: &[I] = concat_slices!([I]: &[I(1), I(2), I(3)]);
+    assert_eq!(TEST6, [I(1), I(2), I(3)]);
 }
 
 #[test]

--- a/tests/smoke.rs
+++ b/tests/smoke.rs
@@ -69,19 +69,54 @@ fn concat_slices_smoke() {
     const TEST2: &[i32] = concat_slices!([i32]: &[1, 2, 3],);
     assert_eq!(TEST2, [1, 2, 3]);
 
-    const TEST3: &[i32] = concat_slices!([i32]: &[1, 2, 3], TEST2);
-    assert_eq!(TEST3, [1, 2, 3, 1, 2, 3]);
+    const TEST3: &[i32] = concat_slices!([i32]: TEST0, TEST1, TEST2);
+    assert_eq!(TEST3, &[1, 2, 3]);
 
-    const TEST4: &[f32] = concat_slices!([f32]: &[1.], &[2.], &[3.]);
-    assert_eq!(TEST4, [1., 2., 3.]);
+    const TEST4: &[i32] = concat_slices!([i32]: &[1, 2, 3], TEST2);
+    assert_eq!(TEST4, [1, 2, 3, 1, 2, 3]);
 
-    const TEST5: &[char] = concat_slices!([char]: &['a'], &['b'], &['c']);
-    assert_eq!(TEST5, ['a', 'b', 'c']);
+    const TEST5: &[f32] = concat_slices!([f32]: &[1.], &[2.], &[3.]);
+    assert_eq!(TEST5, [1., 2., 3.]);
+
+    const TEST6: &[f32] = concat_slices!([f32]: &[4., 5., 6.]);
+    assert_eq!(TEST6, [4., 5., 6.]);
+
+    const TEST7: &[f32] = concat_slices!([f32]: TEST5, TEST6);
+    assert_eq!(TEST7, [1., 2., 3., 4., 5., 6.]);
+
+    const TEST8: &[char] = concat_slices!([char]: &['a'], &['b'], &['c']);
+    assert_eq!(TEST8, ['a', 'b', 'c']);
 
     #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-    struct I(i32);
-    const TEST6: &[I] = concat_slices!([I]: &[I(1), I(2), I(3)]);
-    assert_eq!(TEST6, [I(1), I(2), I(3)]);
+    struct I<T: Sized + Clone>(T);
+    const TEST9: &[I<i32>] = concat_slices!([I<i32>]: &[I(1), I(2), I(3)]);
+    assert_eq!(TEST9, [I(1), I(2), I(3)]);
+
+    const TEST10: &[I<i32>] = concat_slices!([I<i32>]: &[I(4), I(5), I(6)]);
+    assert_eq!(TEST10, [I(4), I(5), I(6)]);
+
+    const TEST11: &[I<i32>] = concat_slices!([I<i32>]: TEST9, TEST10);
+    assert_eq!(TEST11, [I(1), I(2), I(3), I(4), I(5), I(6)]);
+
+    const TEST12: &[I<&str>] =
+        concat_slices!([I<&str>]: &[I("Hello")], &[I("Meh")], &[I("Goodbye")]);
+    assert_eq!(TEST12, [I("Hello"), I("Meh"), I("Goodbye")]);
+
+    const TEST13: &[I<&str>] = concat_slices!([I<&str>]: &[I("One"), I("More"), I("Try")]);
+    assert_eq!(TEST13, [I("One"), I("More"), I("Try")]);
+
+    const TEST14: &[I<&str>] = concat_slices!([I<&str>]: TEST12, TEST13);
+    assert_eq!(
+        TEST14,
+        [
+            I("Hello"),
+            I("Meh"),
+            I("Goodbye"),
+            I("One"),
+            I("More"),
+            I("Try")
+        ]
+    );
 }
 
 #[test]

--- a/tests/smoke.rs
+++ b/tests/smoke.rs
@@ -95,6 +95,9 @@ fn concat_slices_smoke() {
     const DEF: I = I(123);
     const TEST10: &[I] = concat_slices!([DEF; I]: &[I(1), I(2), I(3)]);
     assert_eq!(TEST10, [I(1), I(2), I(3)]);
+
+    const TEST11: &[I] = concat_slices!([I]: &[I(1), I(2), I(3)]);
+    assert_eq!(TEST10, TEST11);
 }
 
 #[test]


### PR DESCRIPTION
This is done by making use of `core::mem::MaybeUninit` and then transmuting the array, once all of the values are initialized.

The older syntax was left in for backwards compatibility purposes.

There is only a single line of unsafe code added as it was required for the change.
The safety of the unsafe block has been explained right above as a comment, its related documentation has been linked.

The related sections in documentation has been updated, and a testing case was added for the change that was made.

That being said, since the PR does introduce unsafe code, and it might not be desired to introduce unsafe code in the library, which I completely understand. 

